### PR TITLE
remove the timestamp in input alias

### DIFF
--- a/upload_shortcuts/upload_shortcuts.py
+++ b/upload_shortcuts/upload_shortcuts.py
@@ -31,7 +31,7 @@ def read_csv(file_name):
             reader = csv.DictReader(file)
             for row in reader:
                 shortcut_data = {
-                    'input_alias': row.get('input_alias') + str(int(time.time())),
+                    'input_alias': row.get('input_alias'),
                     'destination_url': row.get('destination_url'),
                     'created_by': row.get('created_by')
                 }


### PR DESCRIPTION
I was helping a customer upload go links using this script today, and we found that it appends a timestamp to each alias, breaking the links (and leaving the broken links in Glean with no way to bulk delete them 🫤). I'm not sure what the purpose of appending this timestamp is. Gleaned and found a previous same incident here
https://askscio.slack.com/archives/CNZ4N9ZA8/p1746466426219419?thread_ts=1745259795.831519&cid=CNZ4N9ZA8

Since no PR was made to fix this before, I’m raising a PR now to prevent recurrence
