### PR TITLE
Add generic custom API connector with GitHub Actions

### DIFF
--- a/.github/workflows/custom_api_connector.yml
+++ b/.github/workflows/custom_api_connector.yml
@@ -1,0 +1,30 @@
+name: Custom API Connector
+
+on:
+  schedule:
+    # Runs daily at 2:00 AM UTC — adjust as needed
+    - cron: "0 2 * * *"
+  workflow_dispatch: # Allow manual runs
+
+jobs:
+  index:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r custom_api_connector/requirements.txt
+
+      - name: Run connector
+        env:
+          GLEAN_DOMAIN: ${{ secrets.GLEAN_DOMAIN }}
+          GLEAN_API_TOKEN: ${{ secrets.GLEAN_API_TOKEN }}
+          SOURCE_API_TOKEN: ${{ secrets.SOURCE_API_TOKEN }}
+        run: python custom_api_connector/custom_api_connector.py

--- a/custom_api_connector/README.md
+++ b/custom_api_connector/README.md
@@ -1,0 +1,62 @@
+# Custom API Connector
+
+A generic connector that fetches data from any REST API endpoint (with Bearer token auth) and pushes it to Glean via the Indexing API.
+
+## Setup
+
+### 1. Configure `config.json`
+
+Edit `config.json` to match your source API and Glean datasource:
+
+| Field | Description |
+|---|---|
+| `datasource_name` | Unique name for your Glean datasource |
+| `datasource_display_name` | Display name shown in Glean |
+| `datasource_category` | Category (e.g. `PUBLISHED_CONTENT`, `KNOWLEDGE_HUB`) |
+| `object_type` | Document object type |
+| `url_regex` | Regex matching your document URLs |
+| `is_test_datasource` | Set to `false` for production |
+| `source_api.endpoint` | The API URL to fetch data from |
+| `source_api.method` | `GET` or `POST` |
+| `source_api.headers` | Extra headers (auth is handled separately) |
+| `source_api.params` | Query params (GET) or JSON body (POST) |
+| `source_api.results_key` | JSON key containing the array of results (omit if the response is already an array) |
+| `field_mappings.id` | Source field for document ID |
+| `field_mappings.title` | Source field for document title |
+| `field_mappings.body` | Source field for document body/content |
+| `field_mappings.view_url` | Source field for document URL |
+| `field_mappings.mime_type` | MIME type for body content (default: `text/html`) |
+
+### 2. Set environment variables
+
+| Variable | Description |
+|---|---|
+| `GLEAN_DOMAIN` | Your Glean domain (e.g. `mycompany` for `mycompany-be.glean.com`) |
+| `GLEAN_API_TOKEN` | Glean Indexing API token (from Workspace Settings → API Tokens) |
+| `SOURCE_API_TOKEN` | Bearer token for your source API |
+
+### 3. Run locally
+
+```bash
+pip install -r requirements.txt
+
+export GLEAN_DOMAIN="your-domain"
+export GLEAN_API_TOKEN="your-glean-token"
+export SOURCE_API_TOKEN="your-source-api-token"
+
+python custom_api_connector.py
+```
+
+## GitHub Actions
+
+The workflow at `.github/workflows/custom_api_connector.yml` runs this connector on a daily cron schedule.
+
+### Required GitHub Secrets
+
+Add these in your repo → Settings → Secrets and variables → Actions:
+
+- `GLEAN_DOMAIN`
+- `GLEAN_API_TOKEN`
+- `SOURCE_API_TOKEN`
+
+The workflow also supports manual runs via the "Run workflow" button in the Actions tab.

--- a/custom_api_connector/config.json
+++ b/custom_api_connector/config.json
@@ -1,0 +1,24 @@
+{
+  "datasource_name": "custom_api",
+  "datasource_display_name": "Custom API Datasource",
+  "datasource_category": "PUBLISHED_CONTENT",
+  "object_type": "Article",
+  "url_regex": "^https://example.com/.*",
+  "is_test_datasource": true,
+
+  "source_api": {
+    "endpoint": "https://api.example.com/v1/items",
+    "method": "GET",
+    "headers": {},
+    "params": {},
+    "results_key": "results"
+  },
+
+  "field_mappings": {
+    "id": "id",
+    "title": "title",
+    "body": "description",
+    "view_url": "url",
+    "mime_type": "text/html"
+  }
+}

--- a/custom_api_connector/custom_api_connector.py
+++ b/custom_api_connector/custom_api_connector.py
@@ -1,0 +1,174 @@
+import json
+import logging
+import os
+import sys
+import time
+
+import requests
+import glean_indexing_api_client as indexing_api
+from glean_indexing_api_client.api import datasources_api, documents_api
+from glean_indexing_api_client.model.custom_datasource_config import CustomDatasourceConfig
+from glean_indexing_api_client.model.object_definition import ObjectDefinition
+from glean_indexing_api_client.model.bulk_index_documents_request import BulkIndexDocumentsRequest
+from glean_indexing_api_client.model.document_definition import DocumentDefinition
+from glean_indexing_api_client.model.content_definition import ContentDefinition
+from glean_indexing_api_client.model.document_permissions_definition import DocumentPermissionsDefinition
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+PAGE_SIZE = 10
+
+
+def load_config(config_path="config.json"):
+    with open(config_path, "r") as f:
+        return json.load(f)
+
+
+def build_glean_client(glean_domain, glean_api_token):
+    configuration = indexing_api.Configuration(
+        host=f"https://{glean_domain}-be.glean.com/api/index/v1",
+        access_token=glean_api_token,
+    )
+    return indexing_api.ApiClient(configuration)
+
+
+def add_datasource(api_client, config):
+    datasource_config = CustomDatasourceConfig(
+        name=config["datasource_name"],
+        display_name=config["datasource_display_name"],
+        datasource_category=config["datasource_category"],
+        url_regex=config["url_regex"],
+        is_test_datasource=config.get("is_test_datasource", True),
+        object_definitions=[
+            ObjectDefinition(
+                doc_category=config["datasource_category"],
+                name=config["object_type"],
+            )
+        ],
+    )
+    try:
+        api = datasources_api.DatasourcesApi(api_client)
+        api.adddatasource_post(datasource_config)
+        logging.info("Datasource '%s' created/updated.", config["datasource_name"])
+    except indexing_api.ApiException as e:
+        logging.error("Failed to add datasource: %s", e.body)
+        sys.exit(1)
+
+
+def fetch_data(config, source_api_token):
+    source = config["source_api"]
+    headers = {"Authorization": f"Bearer {source_api_token}"}
+    headers.update(source.get("headers", {}))
+
+    method = source.get("method", "GET").upper()
+    if method == "GET":
+        resp = requests.get(source["endpoint"], headers=headers, params=source.get("params", {}))
+    else:
+        resp = requests.post(source["endpoint"], headers=headers, json=source.get("params", {}))
+
+    resp.raise_for_status()
+    data = resp.json()
+
+    results_key = source.get("results_key")
+    if results_key:
+        data = data[results_key]
+
+    logging.info("Fetched %d items from source API.", len(data))
+    return data
+
+
+def build_document(item, config):
+    mappings = config["field_mappings"]
+    datasource = config["datasource_name"]
+    object_type = config["object_type"]
+
+    doc_id = str(item[mappings["id"]])
+    title = str(item[mappings["title"]])
+    body = str(item.get(mappings.get("body", ""), ""))
+    view_url = str(item[mappings["view_url"]])
+    mime_type = mappings.get("mime_type", "text/html")
+
+    return DocumentDefinition(
+        datasource=datasource,
+        object_type=object_type,
+        id=doc_id,
+        title=title,
+        view_url=view_url,
+        body=ContentDefinition(mime_type=mime_type, text_content=body),
+        permissions=DocumentPermissionsDefinition(allow_anonymous_access=True),
+    )
+
+
+def bulk_index(api_client, config, items):
+    upload_id = f"upload-{config['datasource_name']}-{int(time.time())}"
+    doc_api = documents_api.DocumentsApi(api_client)
+    datasource = config["datasource_name"]
+
+    documents = [build_document(item, config) for item in items]
+
+    # Send first page marker
+    doc_api.bulkindexdocuments_post(
+        BulkIndexDocumentsRequest(
+            upload_id=upload_id,
+            datasource=datasource,
+            documents=[],
+            is_first_page=True,
+            is_last_page=False,
+            force_restart_upload=False,
+        )
+    )
+
+    # Send documents in pages
+    for i in range(0, len(documents), PAGE_SIZE):
+        batch = documents[i : i + PAGE_SIZE]
+        doc_api.bulkindexdocuments_post(
+            BulkIndexDocumentsRequest(
+                upload_id=upload_id,
+                datasource=datasource,
+                documents=batch,
+                is_first_page=False,
+                is_last_page=False,
+                force_restart_upload=False,
+            )
+        )
+        logging.info("Indexed batch %d-%d of %d.", i + 1, i + len(batch), len(documents))
+
+    # Send last page marker
+    doc_api.bulkindexdocuments_post(
+        BulkIndexDocumentsRequest(
+            upload_id=upload_id,
+            datasource=datasource,
+            documents=[],
+            is_first_page=False,
+            is_last_page=True,
+            force_restart_upload=False,
+        )
+    )
+
+    logging.info("Bulk indexing complete. Upload ID: %s", upload_id)
+
+
+def main():
+    # Required env vars
+    glean_domain = os.environ.get("GLEAN_DOMAIN")
+    glean_api_token = os.environ.get("GLEAN_API_TOKEN")
+    source_api_token = os.environ.get("SOURCE_API_TOKEN")
+
+    if not all([glean_domain, glean_api_token, source_api_token]):
+        logging.error("Missing required env vars: GLEAN_DOMAIN, GLEAN_API_TOKEN, SOURCE_API_TOKEN")
+        sys.exit(1)
+
+    config_path = os.environ.get("CONFIG_PATH", os.path.join(os.path.dirname(__file__), "config.json"))
+    config = load_config(config_path)
+
+    api_client = build_glean_client(glean_domain, glean_api_token)
+
+    add_datasource(api_client, config)
+    items = fetch_data(config, source_api_token)
+    bulk_index(api_client, config, items)
+
+    logging.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/custom_api_connector/requirements.txt
+++ b/custom_api_connector/requirements.txt
@@ -1,0 +1,8 @@
+certifi==2023.7.22
+charset-normalizer==3.2.0
+glean-indexing-api-client @ https://app.glean.com/meta/indexing_api_client.zip
+idna==3.4
+python-dateutil==2.8.2
+requests==2.31.0
+six==1.16.0
+urllib3==2.0.4


### PR DESCRIPTION
## Description
- Adds a generic custom connector (`custom_api_connector/`) that fetches data from any REST API endpoint with Bearer token auth and pushes documents to Glean via the Indexing API
- All configuration (endpoint URL, field mappings, datasource settings) is driven by `config.json` — no code changes needed to adapt to a new API
- Includes a GitHub Actions workflow (`.github/workflows/custom_api_connector.yml`) with daily cron schedule and manual dispatch support

### How to use
1. Edit `custom_api_connector/config.json` — set your API endpoint, field mappings, and datasource details
2. Add three GitHub Secrets: `GLEAN_DOMAIN`, `GLEAN_API_TOKEN`, `SOURCE_API_TOKEN`
3. The workflow runs daily at 2:00 AM UTC, or trigger manually from the Actions tab

## Testing
- [ ] Set up secrets and run workflow manually via `workflow_dispatch`
- [ ] Verify documents appear in Glean after indexing
- [ ] Test with a different source API by updating `config.json`

___
🤖 *Generated by Glean Code Writer*
📝 Chat link - https://app.glean.com/chat/592f63fc58a34028a158dd5498372289